### PR TITLE
make Dashboard

### DIFF
--- a/src/resources/views/components/layouts/app.blade.php
+++ b/src/resources/views/components/layouts/app.blade.php
@@ -20,13 +20,10 @@
         @endif
 
 </head>
-<body>
+<body class="bg-gray-100 text-gray-800 min-h-screen flex flex-col">
+
+    {{ $content }}
 
 
-        <div class="main-part">
-            {{ $content }}
-
-        </div>
-        
 </body>
 </html>

--- a/src/resources/views/components/layouts/layout.blade.php
+++ b/src/resources/views/components/layouts/layout.blade.php
@@ -1,0 +1,62 @@
+{{-- resources/views/components/layout.blade.php --}}
+@props(['title' => '農作業日誌アプリ'])
+
+<x-layouts.app>
+    <x-slot:content>
+        <!-- 共通ナビゲーションバー -->
+        <header class="bg-white shadow-sm border-b border-gray-200">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
+                <!-- アプリロゴ・タイトル -->
+                <div class="flex items-center space-x-8">
+                    <a href="{{ route('dashboard') }}" class="text-xl font-bold text-green-700 hover:text-green-800">
+                        🌱 農作業日誌
+                    </a>
+
+                    <!-- ナビゲーションリンク -->
+                    <nav class="hidden md:flex space-x-4">
+                        <a href="{{ route('dashboard') }}"
+                            class="px-3 py-2 rounded-md text-sm font-medium {{ request()->routeIs('dashboard') ? 'bg-green-100 text-green-800' : 'text-gray-600 hover:bg-gray-100' }}">
+                            ダッシュボード
+                        </a>
+                        <a href="{{ route('create') }}"
+                            class="px-3 py-2 rounded-md text-sm font-medium {{ request()->routeIs('create') ? 'bg-green-100 text-green-800' : 'text-gray-600 hover:bg-gray-100' }}">
+                            作業登録
+                        </a>
+                        <!-- 今後作成する作付別閲覧ページ用 -->
+                        <a href="#"
+                            class="px-3 py-2 rounded-md text-sm font-medium text-gray-600 hover:bg-gray-100">
+                            作付別日誌 (作成予定)
+                        </a>
+                    </nav>
+                </div>
+
+                <!-- 右側（クイックアクション等） -->
+                <div>
+                    <a href="{{ route('create') }}" class="bg-green-600 hover:bg-green-700 text-white text-sm font-bold py-2 px-4 rounded shadow">
+                        + 新規登録
+                    </a>
+                </div>
+            </div>
+        </header>
+
+        <!-- ページコンテンツ領域 -->
+        <main class="flex-grow max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-6">
+            <!-- ページ見出し（スロット指定があれば表示） -->
+            @if (isset($header))
+                <div class="mb-6">
+                    <h1 class="text-2xl font-bold text-gray-900">{{ $header }}</h1>
+                </div>
+            @endif
+
+            <!-- メインコンテンツ -->
+            {{ $slot }}
+        </main>
+
+        <!-- 共通フッター -->
+        <footer class="bg-white border-t border-gray-200 py-4 mt-auto">
+            <div class="max-w-7xl mx-auto px-4 text-center text-xs text-gray-500">
+                &copy; {{ date('Y') }} 農作業管理システム
+            </div>
+        </footer>
+    </x-slot>
+</x-layouts.app>

--- a/src/resources/views/components/work-logs/application/create.blade.php
+++ b/src/resources/views/components/work-logs/application/create.blade.php
@@ -1,39 +1,8 @@
-<x-layouts.app>
-
-<x-slot:content>
-
-    <div class="main-container grid grid-cols-[minmax(min-content,_800px)] gap-4 px-2 place-content-center bg-green-50 min-h-screen ">
+@props([''])
 
 
-        {{ $title }}
+<div class="mx-20">
 
-        {{ $formHead }}
-        
+    {{ $slot }}
 
-        {{ $header }}
-
-        <x-work-logs.draft-ui />
-
-
-        <div class="input-form-inner ">
-
-            <x-work-logs.basic-form-section />
-
-            <x-work-logs.material-logs />
-
-
-        </div>
-
-        {{ $bottom }}
-
-        </form>
-
-
-    </div>
-</x-slot>
-
-
-</x-layouts.app>
-
-
-
+</div>

--- a/src/resources/views/dashboard.blade.php
+++ b/src/resources/views/dashboard.blade.php
@@ -1,0 +1,29 @@
+{{-- resources/views/dashboard.blade.php --}}
+<x-layouts.layout title="ダッシュボード - 農作業日誌">
+    <x-slot:header>
+        ダッシュボード
+    </x-slot:header>
+
+    <!-- 開発時用のクイックナビゲーションカード -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+
+        <!-- 作業登録へ -->
+        <div class="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+            <h2 class="text-lg font-bold text-gray-800 mb-2">📝 作業の登録</h2>
+            <p class="text-sm text-gray-600 mb-4">本日の作業内容や使用資材を記録します。</p>
+            <a href="{{ route('create') }}" class="inline-block bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded text-sm">
+                作業登録画面を開く &rarr;
+            </a>
+        </div>
+
+        <!-- 作付別閲覧へ（今後の開発対象） -->
+        <div class="bg-white p-6 rounded-lg shadow-sm border border-gray-200 opacity-75">
+            <h2 class="text-lg font-bold text-gray-800 mb-2">📊 作付別日誌閲覧（開発予定）</h2>
+            <p class="text-sm text-gray-600 mb-4">作物ごとの作業履歴や年次ガントチャートを確認します。</p>
+            <button disabled class="bg-gray-300 text-gray-600 font-bold py-2 px-4 rounded text-sm cursor-not-allowed">
+                順次開発中...
+            </button>
+        </div>
+
+    </div>
+</x-layouts.layout>

--- a/src/resources/views/work-logs/create.blade.php
+++ b/src/resources/views/work-logs/create.blade.php
@@ -1,20 +1,11 @@
-<x-work-logs.application.create>
-
-<x-slot:buttons>
-
-</x-slot:buttons>
-
-
-    <x-slot:title>
-        <div class="title-wrapper py-5 my-5 text-center">
-            <h2 class="font-bold text-3xl">作業登録</h2>
-        </div>
+<x-layouts.layout title="日誌記録画面 - 農作業日誌">
+    <x-slot:header>
+        日誌記録
     </x-slot>
 
+    <x-work-logs.application.create>
 
-    <x-slot:formHead>
         <div class="input-form-wrapper">
-
             <form
                 x-data="postForm({
                     initialMaterials: @js($materials),
@@ -26,10 +17,7 @@
                 action="{{ route('store') }}"
                 method="post"
             >
-
                 @csrf
-    </x-slot>
-    <x-slot:header>
 
                 {{-- デバッグ用のネットワーク状態インジケータ --}}
                 <div class="grid grid-cols-3">
@@ -40,14 +28,21 @@
                     </div>
                 </div>
 
-
                 <div class="block text-sm font-medium text-gray-700 mb-2" >
                     作業登録者：　<span x-text="allUsers[0].name"></span>
                 </div>
 
-    </x-slot>
+                <x-work-logs.draft-ui />
 
-                <x-slot:bottom>
+
+                <div class="input-form-inner ">
+
+                <x-work-logs.basic-form-section />
+
+                <x-work-logs.material-logs />
+
+            </div>
+
                     {{-- 下部ボタンエリア --}}
                     <div class="submit-button grid grid-cols-3 gap-2  sm:max-w-1/2 ">
                         <x-ui.button type="submit" variant="primary" >
@@ -65,7 +60,9 @@
                         </x-ui.button>
                         {{-- <div x-show="isDraft" class="grid place-content-center rounded-md bg-gray-400 text-bold text-white ">下書きをやめて新しい記録として保存</div> --}}
                     </div>
-                </x-slot>
-            </div>
+            </form>
 
-</x-application.work-logs.create>
+        </div>
+
+    </x-work-logs.application.create>
+</x-layouts.layout>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -7,13 +7,17 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Http\Request;
 
 
-Route::get('/', function () {
-    return view('welcome');
-});
+// Route::get('/', function () {
+//     return view('welcome');
+// });
 
 
 Route::get('/work-logs/create', [WorkController::class, 'create'])->name('create');
 Route::post('/work-logs/create', [WorkController::class, 'store'])->name('store');
+
+Route::get('/', function () {
+    return view('dashboard');
+})->name('dashboard');
 // Route::post('/create', function (Request $request) {
 //     dd($request);
 // })->name('store');


### PR DESCRIPTION
ダッシュボードおよびナビゲーションバーを含んだ基本レイアウトコンポーネントを作成した。
ほぼgeminiが出力したコードを転記した。 前タクスで作成した作業登録画面がテンプレートに収まるように微調整。

> todo 閲覧画面あたりを作成する。
ダッシュボード右側に現在扱っている作付け作物の一覧表を表示させる。
可能ならmeta情報付きで。 

> todo １日分の日誌を表示させる画面設計を決める。
PC画面なら画面を左右に２分割として、半分に縦タイムライン、もう半分にクリックした当日の記録を表示させるか。
スマホ画面ではタップしてモーダル？タブレット画面では？

> todo 表示できる領域がかなりあるので、ゆくゆくは画像の添付と表示の機能を。画質・ファイルサイズ圧縮、日付。